### PR TITLE
Juju Kilo

### DIFF
--- a/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
@@ -77,3 +77,12 @@ echo "     It must be an accessible interface from your OpenStack system,"
 echo "     and that interface must be one that accepts AMQP connections for "
 echo "     your Zenoss installation."
 
+# Export all the credentials to a separate file at /home/zenoss
+touch /home/zenoss/openstack_amqp
+echo "export ZENOSS_DEVICE=OpenStack" >> /home/zenoss/openstack_amqp
+echo "export AMQP_USERID=$AMQP_USERID" >> /home/zenoss/openstack_amqp
+echo "export AMQP_PASSWORD=$AMQP_PASSWORD" >> /home/zenoss/openstack_amqp
+echo "export AMQP_PORT=$AMQP_PORT" >> /home/zenoss/openstack_amqp
+echo "export AMQP_VIRTUAL_HOST=$AMQP_VIRTUAL_HOST" >> /home/zenoss/openstack_amqp
+echo "export AMQP_HOSTNAME=$DEFAULT_IP" >> /home/zenoss/openstack_amqp
+

--- a/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
@@ -43,7 +43,7 @@ CURRENTDIR="$(dirname "$(which "$0")")"
 PARENTDIR=$(dirname $CURRENTDIR)
 
 # Create any required exchanges
-$PARENTDIR/openstack_amqp_init.py
+#$PARENTDIR/openstack_amqp_init.py
 
 echo ""
 echo "OpenStack Configuration"

--- a/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
@@ -6,6 +6,8 @@ echo "RabbitMQ Configuration"
 echo "--------------------"
 echo "If using Europa, you *MUST* use this command in a rabbitmq container"
 
+source /home/zenoss/zenoss_env
+
 AMQP_USERID="openstack"
 AMQP_PASSWORD="[previously configured password]"
 AMQP_HOSTNAME=`zenglobalconf -p amqphost`

--- a/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
+++ b/ZenPacks/zenoss/OpenStackInfrastructure/bin/openstack_amqp_config
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo $0
 


### PR DESCRIPTION
#This pull request contains some changes to the openstack_amqp_config bash script that creates and configures the OpenStack RabbitMQ user in the Zenoss machine.

The modification will write the OpenStack RabbitMQ credentials data to /home/zenoss where it will be sourced by the Juju hooks when adding relations with other OpenStack component charms.